### PR TITLE
feat: build a universal binary on macOS

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -30,10 +30,16 @@ jobs:
         run: |
           npm install -g pnpm
           pnpm install --frozen-lockfile
+      - name: configure macOS build
+        if: matrix.platform == 'macos-latest'
+        run: |
+          # Ensure that we have the aarch64 toolchain available for cross-compilation
+          rustup target add aarch64-apple-darwin
       - uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
+          args: ${{ matrix.platform == 'macos-latest' && '--target universal-apple-darwin' || '' }}
           tagName: v__VERSION__-dev.${{ github.run_number }} # the action automatically replaces \_\_VERSION\_\_ with the app version
           releaseName: "Development Build v__VERSION__-dev.${{ github.run_number }}"
           releaseBody: "This is a development release from the master branch (Commit ${{ github.sha }})."

--- a/README.md
+++ b/README.md
@@ -46,6 +46,14 @@ pnpm tauri dev # or cargo-tauri dev
 pnpm tauri build # or cargo-tauri build
 ```
 
+### Note about running on macOS
+
+When running Typstudio for the first time on macOS, you may see a warning saying that the "Developer can not be verified". This is only a one-time warning for new files downloaded from the internet that aren't notarized.
+
+To be able to work around it, perform the following steps:
+- Right click on the application, and then click "Open"
+- Then, you'll see *yet another* warning from Gatekeeper, just click "Open" again to launch Typstudio
+
 ### Learn more
 
 - [Tauri](https://tauri.app/v1/guides/)


### PR DESCRIPTION
Prior to this, a `x86_64` binary for macOS was being built, which is *fine* - but a universal binary is always desired :)

To build for `aarch64`, we need to do the following:
- Install the rust toolchain for the `aarch64-apple-darwin` target 
- Pass ``--target universal-apple-darwin`` to the tauri action if running on macOS

I did this in the cleanest way possible, and from my initial testing, it appears to function.

Fixes #9.