### PR TITLE
feat: add the ability to toggle the preview's visibility 

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "prettier.documentSelectors": ["**/*.svelte"]
+}

--- a/src-tauri/src/ipc/events/mod.rs
+++ b/src-tauri/src/ipc/events/mod.rs
@@ -1,0 +1,1 @@
+pub mod view;

--- a/src-tauri/src/ipc/events/view.rs
+++ b/src-tauri/src/ipc/events/view.rs
@@ -1,0 +1,11 @@
+use serde::Serialize;
+use tauri::{Runtime, Window};
+
+// For some reason, Tauri requires an event payload...
+#[derive(Debug, Clone, Serialize)]
+struct EmptyPayload {}
+
+// Instructs the front-end to hide or show the preview
+pub fn toggle_preview_visibility<R: Runtime>(window: &Window<R>) {
+    let _ = window.emit("toggle_preview_visibility", EmptyPayload {});
+}

--- a/src-tauri/src/ipc/mod.rs
+++ b/src-tauri/src/ipc/mod.rs
@@ -1,4 +1,5 @@
 pub mod commands;
+pub mod events;
 
 mod model;
 pub use model::*;

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -57,7 +57,10 @@ fn build_menu() -> Menu {
             .add_item(CustomMenuItem::new("file_quit", "Quit")),
     );
     let edit_submenu = Submenu::new("Edit", Menu::new());
-    let view_submenu = Submenu::new("View", Menu::new());
+    let view_submenu = Submenu::new(
+        "View",
+        Menu::new().add_item(CustomMenuItem::new("view_toggle_preview", "Toggle Preview")),
+    );
 
     Menu::new()
         .add_submenu(file_submenu)

--- a/src-tauri/src/menu.rs
+++ b/src-tauri/src/menu.rs
@@ -1,3 +1,4 @@
+use crate::ipc::events::view;
 use crate::project::{Project, ProjectManager};
 use std::fs;
 use std::sync::Arc;
@@ -38,6 +39,9 @@ pub fn handle_menu_event<R: Runtime>(e: WindowMenuEvent<R>) {
             }),
         "file_quit" => {
             e.window().app_handle().exit(0);
+        }
+        "view_toggle_preview" => {
+            view::toggle_preview_visibility(e.window());
         }
         _ => {}
     }


### PR DESCRIPTION
The preview window can now be hidden through a "Toggle Preview" option in the "View" menu!

Notes:
- I also added a `.vscode/settings.json` file which forces the Prettier extension to format .svelte files, for some reason it doesn't recognize the file type by default...
- Closes #13 