### PR TITLE
chore: Improve menu bar

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -13,7 +13,7 @@ use crate::project::ProjectManager;
 use env_logger::Env;
 use log::info;
 use std::sync::Arc;
-use tauri::{CustomMenuItem, Menu, MenuItem, Submenu, Wry};
+use tauri::{AboutMetadata, CustomMenuItem, Menu, MenuItem, Submenu, Wry};
 
 #[tokio::main]
 async fn main() {
@@ -46,7 +46,24 @@ async fn main() {
 }
 
 fn build_menu() -> Menu {
-    let application_menu = Submenu::new("Typstudio", Menu::new().add_native_item(MenuItem::Quit));
+    let application_menu = Submenu::new(
+        "Typstudio",
+        Menu::new()
+            .add_native_item(MenuItem::About(
+                "Typstudio".into(),
+                AboutMetadata::default(),
+            ))
+            // All of the non-seperator items are macOS specific... it helps it fit in as a "native" application though
+            .add_native_item(MenuItem::Separator)
+            .add_native_item(MenuItem::Services)
+            .add_native_item(MenuItem::Separator)
+            .add_native_item(MenuItem::Hide)
+            .add_native_item(MenuItem::HideOthers)
+            .add_native_item(MenuItem::ShowAll)
+            .add_native_item(MenuItem::Separator)
+            // This one is not though!
+            .add_native_item(MenuItem::Quit),
+    );
 
     let file_submenu = Submenu::new(
         "File",

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -13,7 +13,7 @@ use crate::project::ProjectManager;
 use env_logger::Env;
 use log::info;
 use std::sync::Arc;
-use tauri::{CustomMenuItem, Menu, Submenu, Wry};
+use tauri::{CustomMenuItem, Menu, MenuItem, Submenu, Wry};
 
 #[tokio::main]
 async fn main() {
@@ -46,6 +46,8 @@ async fn main() {
 }
 
 fn build_menu() -> Menu {
+    let application_menu = Submenu::new("Typstudio", Menu::new().add_native_item(MenuItem::Quit));
+
     let file_submenu = Submenu::new(
         "File",
         Menu::new()
@@ -53,13 +55,13 @@ fn build_menu() -> Menu {
             .add_submenu(Submenu::new(
                 "Export",
                 Menu::new().add_item(CustomMenuItem::new("file_export_pdf", "Export PDF")),
-            ))
-            .add_item(CustomMenuItem::new("file_quit", "Quit")),
+            )),
     );
     let edit_submenu = Submenu::new("Edit", Menu::new());
     let view_submenu = Submenu::new("View", Menu::new());
 
     Menu::new()
+        .add_submenu(application_menu)
         .add_submenu(file_submenu)
         .add_submenu(edit_submenu)
         .add_submenu(view_submenu)

--- a/src-tauri/src/menu.rs
+++ b/src-tauri/src/menu.rs
@@ -36,7 +36,7 @@ pub fn handle_menu_event<R: Runtime>(e: WindowMenuEvent<R>) {
                     }
                 }
             }),
-        "file_quit" => {
+        "quit" => {
             e.window().app_handle().exit(0);
         }
         _ => {}


### PR DESCRIPTION
Most of the changes are related to macOS, however, the first commit (b0ad49ffc7869c44e94d3abf31049a4848a96baa) is beneficial to all platforms, as it allows us to use the system-specified hotkey for quitting the application.

Preview of the new menu actions on macOS:

> **Note**
> A very basic auto-generated "About" dialog has also been added with this, but we can fill out that information later...

<img width="304" alt="image" src="https://github.com/Cubxity/typstudio/assets/71222289/0dc19294-0c21-448d-a18f-6913d8cad855">

v.s. Terminal, a "native" application:
<img width="295" alt="image" src="https://github.com/Cubxity/typstudio/assets/71222289/0c31fee0-1ec0-4270-90af-a79192795b91">

*As you can see, we now have the same default actions in our application menu as the other apps!*
