### PR TITLE
Tiny tweaks in default editor settings

### DIFF
--- a/src/components/Editor.svelte
+++ b/src/components/Editor.svelte
@@ -56,7 +56,9 @@
       automaticLayout: true,
       readOnly: true,
       folding: true,
-      quickSuggestions: false
+      quickSuggestions: false,
+      wordWrap: "on",
+      unicodeHighlight: { ambiguousCharacters: false },
     });
 
     editor.onDidChangeModel((e: IModelChangedEvent) => {


### PR DESCRIPTION
It was a bit suprising to me that there was no word-wrapping by default and no way to enable it. Typst is a language used for typing texts, and adding manual breaks that don't matter is quite meaningless. Also I had issues with default ambigous unicode highlight (Cyryllic, there are numerous charachters that look like Latin, thus I had lots of yellow squares in my text).

So I added these settings to editor initialize to make it a bit more useful. I suppose that in future they should be customizable, but in any case that seems to me as a reasonable default.  