### PR TITLE
fix: autocomplete on windows

### DIFF
--- a/src-tauri/src/ipc/commands/typst.rs
+++ b/src-tauri/src/ipc/commands/typst.rs
@@ -203,7 +203,7 @@ pub async fn typst_autocomplete<R: Runtime>(
     offset: usize,
     explicit: bool,
 ) -> Result<TypstCompleteResponse> {
-    let (project, path) = project_path(&window, &project_manager, path)?;
+    let project = project(&window, &project_manager)?;
     let mut world = project.world.lock().unwrap();
 
     let offset = content

--- a/src/lib/editor/completion.ts
+++ b/src/lib/editor/completion.ts
@@ -16,7 +16,7 @@ export class TypstCompletionProvider implements languages.CompletionItemProvider
   ): Promise<languages.CompletionList> {
     console.log("completing", position, context);
     const { offset: completionOffset, completions } = await autocomplete(
-      model.uri.path.substring(1),
+      model.uri.path,
       model.getValue(),
       model.getOffsetAt(position),
       context.triggerKind === CompletionTriggerKind.Invoke


### PR DESCRIPTION
Autocomplete on Windows didn't work due to improper path handling. Fixes #26.