### PR TITLE
fix: explicitly add the application name as a menu

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -13,7 +13,7 @@ use crate::project::ProjectManager;
 use env_logger::Env;
 use log::info;
 use std::sync::Arc;
-use tauri::{CustomMenuItem, Menu, Submenu, Wry};
+use tauri::{AboutMetadata, CustomMenuItem, Menu, MenuItem, Submenu, Wry};
 
 #[tokio::main]
 async fn main() {
@@ -49,6 +49,14 @@ fn build_menu() -> Menu {
     let application_menu = Submenu::new(
         "typstudio",
         Menu::new()
+            .add_native_item(MenuItem::About(String::from("typstudio"), AboutMetadata::new()))
+            .add_native_item(MenuItem::Separator)
+            .add_native_item(MenuItem::Hide)
+            .add_native_item(MenuItem::HideOthers)
+            .add_native_item(MenuItem::ShowAll)
+            .add_native_item(MenuItem::Separator)
+            .add_native_item(MenuItem::Quit)
+
     );
 
     let file_submenu = Submenu::new(
@@ -67,9 +75,12 @@ fn build_menu() -> Menu {
         Menu::new().add_item(CustomMenuItem::new("view_toggle_preview", "Toggle Preview")),
     );
 
-    Menu::new()
-        .add_submenu(application_menu)
-        .add_submenu(file_submenu)
+    let mut menu = Menu::new();
+    #[cfg(target_os = "macos")]
+    {
+        menu = menu.add_submenu(application_menu)
+    }
+    menu.add_submenu(file_submenu)
         .add_submenu(edit_submenu)
         .add_submenu(view_submenu)
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -55,19 +55,24 @@ fn build_menu() -> Menu {
             .add_native_item(MenuItem::HideOthers)
             .add_native_item(MenuItem::ShowAll)
             .add_native_item(MenuItem::Separator)
-            .add_native_item(MenuItem::Quit)
-
+            .add_native_item(MenuItem::Quit),
     );
+
+    let mut file_menu = Menu::new()
+        .add_item(CustomMenuItem::new("file_open_project", "Open Project"))
+        .add_submenu(Submenu::new(
+            "Export",
+            Menu::new().add_item(CustomMenuItem::new("file_export_pdf", "Export PDF")),
+        ));
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        file_menu = file_menu.add_native_item(MenuItem::Quit);
+    }
 
     let file_submenu = Submenu::new(
         "File",
-        Menu::new()
-            .add_item(CustomMenuItem::new("file_open_project", "Open Project"))
-            .add_submenu(Submenu::new(
-                "Export",
-                Menu::new().add_item(CustomMenuItem::new("file_export_pdf", "Export PDF")),
-            ))
-            .add_item(CustomMenuItem::new("file_quit", "Quit")),
+        file_menu,
     );
     let edit_submenu = Submenu::new("Edit", Menu::new());
     let view_submenu = Submenu::new(

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -46,6 +46,11 @@ async fn main() {
 }
 
 fn build_menu() -> Menu {
+    let application_menu = Submenu::new(
+        "typstudio",
+        Menu::new()
+    );
+
     let file_submenu = Submenu::new(
         "File",
         Menu::new()
@@ -63,6 +68,7 @@ fn build_menu() -> Menu {
     );
 
     Menu::new()
+        .add_submenu(application_menu)
         .add_submenu(file_submenu)
         .add_submenu(edit_submenu)
         .add_submenu(view_submenu)

--- a/src-tauri/src/menu.rs
+++ b/src-tauri/src/menu.rs
@@ -37,9 +37,6 @@ pub fn handle_menu_event<R: Runtime>(e: WindowMenuEvent<R>) {
                     }
                 }
             }),
-        "file_quit" => {
-            e.window().app_handle().exit(0);
-        }
         "view_toggle_preview" => {
             view::toggle_preview_visibility(e.window());
         }


### PR DESCRIPTION
tested on macos
if could be tested on windows and linux by somebody would be great